### PR TITLE
fix: cambiar StatusPicker de menú circular a popover con grid

### DIFF
--- a/nextjs-app/src/components/pedidos/StatusPicker.tsx
+++ b/nextjs-app/src/components/pedidos/StatusPicker.tsx
@@ -12,8 +12,6 @@ interface StatusPickerProps {
 
 export default function StatusPicker({ currentStatus, anchorRect, onSelect, onClose }: StatusPickerProps) {
   const ref = useRef<HTMLDivElement>(null);
-  const [hoveredLabel, setHoveredLabel] = useState("Selecciona un estado");
-  const [hoveredColor, setHoveredColor] = useState("#717973");
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
@@ -37,92 +35,99 @@ export default function StatusPicker({ currentStatus, anchorRect, onSelect, onCl
     };
   }, [onClose]);
 
-  // Center the menu on the clicked badge
-  const menuSize = 280;
-  const radius = 95;
-  const centerX = anchorRect.left + anchorRect.width / 2;
-  const centerY = anchorRect.top + anchorRect.height / 2;
+  // Position popover below the badge, centered horizontally
+  const popoverWidth = 280;
+  const gap = 8;
+  const padding = 12;
+
+  let left = anchorRect.left + anchorRect.width / 2 - popoverWidth / 2;
+  let top = anchorRect.bottom + gap;
 
   // Clamp to viewport
-  const padding = 10;
-  const left = Math.max(padding, Math.min(centerX - menuSize / 2, window.innerWidth - menuSize - padding));
-  const top = Math.max(padding, Math.min(centerY - menuSize / 2, window.innerHeight - menuSize - padding));
+  left = Math.max(padding, Math.min(left, window.innerWidth - popoverWidth - padding));
 
-  const numItems = STATUS_OPTIONS.length;
-  const angleStep = 360 / numItems;
+  // If not enough space below, show above
+  const estimatedHeight = 320;
+  if (top + estimatedHeight > window.innerHeight - padding) {
+    top = anchorRect.top - estimatedHeight - gap;
+  }
+  // Clamp top
+  top = Math.max(padding, top);
 
   return (
     <div
       ref={ref}
       className="fixed z-[70]"
-      style={{ left, top, width: menuSize, height: menuSize }}
+      style={{
+        left,
+        top,
+        width: popoverWidth,
+        opacity: mounted ? 1 : 0,
+        transform: mounted ? "translateY(0) scale(1)" : "translateY(-8px) scale(0.97)",
+        transition: "opacity 0.2s ease, transform 0.2s ease",
+      }}
     >
-      {/* Info bar */}
-      <div
-        className="absolute left-1/2 -translate-x-1/2 -top-10 px-4 py-1.5 rounded-full text-xs font-bold text-white whitespace-nowrap transition-all duration-200 shadow-lg"
-        style={{ backgroundColor: hoveredColor }}
-      >
-        {hoveredLabel}
-      </div>
+      <div className="bg-white rounded-xl shadow-2xl border border-gray-100 overflow-hidden">
+        {/* Header */}
+        <div className="px-4 pt-3 pb-2">
+          <p className="text-xs font-semibold text-gray-400 uppercase tracking-wide">
+            Cambiar estado
+          </p>
+        </div>
 
-      {/* Circular menu items */}
-      <div className="relative w-full h-full">
-        {STATUS_OPTIONS.map((status, index) => {
-          const angle = (angleStep * index - 90) * (Math.PI / 180);
-          const x = Math.cos(angle) * radius;
-          const y = Math.sin(angle) * radius;
-          const isActive = status.label === currentStatus;
+        {/* Grid of status options */}
+        <div className="px-3 pb-3 grid grid-cols-2 gap-1.5">
+          {STATUS_OPTIONS.map((status, index) => {
+            const isActive = status.label === currentStatus;
 
-          return (
-            <div
-              key={status.id}
-              className="absolute flex flex-col items-center gap-0.5 cursor-pointer group"
-              style={{
-                left: "50%",
-                top: "50%",
-                transform: mounted
-                  ? `translate(calc(-50% + ${x}px), calc(-50% + ${y}px)) scale(1)`
-                  : `translate(-50%, -50%) scale(0)`,
-                transition: `transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1) ${index * 30}ms`,
-              }}
-              onMouseEnter={() => {
-                setHoveredLabel(status.label);
-                setHoveredColor(status.color);
-              }}
-              onMouseLeave={() => {
-                setHoveredLabel("Selecciona un estado");
-                setHoveredColor("#717973");
-              }}
-              onClick={(e) => {
-                e.stopPropagation();
-                if (!isActive) onSelect(status.label);
-                onClose();
-              }}
-            >
-              <div
-                className={`w-11 h-11 rounded-full flex items-center justify-center transition-all duration-200 group-hover:scale-[1.15] shadow-md ${
-                  isActive ? "ring-3 ring-offset-2" : ""
+            return (
+              <button
+                key={status.id}
+                className={`flex items-center gap-2.5 px-3 py-2.5 rounded-lg cursor-pointer transition-all duration-150 text-left group ${
+                  isActive
+                    ? "ring-2 ring-offset-1"
+                    : "hover:bg-gray-50 active:scale-[0.97]"
                 }`}
                 style={{
-                  backgroundColor: `${status.color}20`,
-                  color: status.color,
-                  ...(isActive && { ringColor: status.color }),
-                  boxShadow: isActive ? `0 0 0 3px ${status.color}40` : undefined,
+                  backgroundColor: isActive ? `${status.color}12` : undefined,
+                  ringColor: isActive ? status.color : undefined,
+                  boxShadow: isActive ? `0 0 0 2px ${status.color}30` : undefined,
+                  opacity: mounted ? 1 : 0,
+                  transform: mounted ? "translateY(0)" : "translateY(6px)",
+                  transition: `all 0.2s ease ${index * 25}ms`,
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (!isActive) onSelect(status.label);
+                  onClose();
                 }}
               >
-                <span className="material-symbols-outlined text-lg" style={{ color: status.color }}>
-                  {status.icon}
+                {/* Icon circle */}
+                <div
+                  className="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 transition-transform duration-150 group-hover:scale-110"
+                  style={{
+                    backgroundColor: `${status.color}18`,
+                    color: status.color,
+                  }}
+                >
+                  <span className="material-symbols-outlined text-base" style={{ color: status.color }}>
+                    {status.icon}
+                  </span>
+                </div>
+
+                {/* Label */}
+                <span
+                  className={`text-xs leading-tight font-medium ${
+                    isActive ? "font-bold" : "text-gray-700"
+                  }`}
+                  style={isActive ? { color: status.color } : undefined}
+                >
+                  {status.label}
                 </span>
-              </div>
-              <span
-                className="text-[9px] font-bold text-center leading-tight max-w-[60px] transition-opacity duration-200"
-                style={{ color: status.color }}
-              >
-                {status.label}
-              </span>
-            </div>
-          );
-        })}
+              </button>
+            );
+          })}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Reemplaza el menú circular/radial del StatusPicker por un popover compacto con grid de 2 columnas
- Cada opción mantiene su icono con color y label, igual de visual pero más usable
- Se posiciona debajo del badge clickeado (o arriba si no hay espacio), sin tapar otras filas de la tabla

## Test plan
- [ ] Verificar que el popover aparece al hacer clic en un estatus en la tabla
- [ ] Verificar que cambia el estatus correctamente al seleccionar una opción
- [ ] Verificar que se cierra con Escape o clic fuera
- [ ] Verificar posicionamiento correcto en filas superiores e inferiores

🤖 Generated with [Claude Code](https://claude.com/claude-code)