### PR TITLE
fix(crm): registrar ruta /crm/carritos-abandonados

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -135,7 +135,7 @@ app.get('/crm', (req, res) => {
 const crmSections = [
     'chats', 'departamentos', 'reglas-ads', 'etiquetas',
     'mensajes-ads', 'respuestas-rapidas', 'entrenamiento-ia',
-    'simulador-ia', 'ajustes'
+    'simulador-ia', 'ajustes', 'carritos-abandonados'
 ];
 crmSections.forEach(section => {
     app.get(`/crm/${section}`, (req, res) => {


### PR DESCRIPTION
Fix rápido: el array `crmSections` en `server/index.js` no incluía `carritos-abandonados`, por lo que Express respondía HTML fallback en vez del HTML estático de Next.js. Esto causaba errores de MIME type en el browser.

1 línea de cambio.