### PR TITLE
admon: agregar 'jovita' a regla Sueldos en utils.js

### DIFF
--- a/public/admon/js/utils.js
+++ b/public/admon/js/utils.js
@@ -207,7 +207,7 @@ export function autoCategorizeWithRulesOnly(concept) {
         Publicidad: ['facebook'],
         Material: ['material', 'raza', 'c00008749584', 'acrilico', 'mercadolibre', 'psa computo'],
         Envios: ['guias'], 
-        Sueldos: ['diego', 'catalina', 'rosario', 'erika', 'catarina', 'maria gua', 'karla', 'lupita', 'recargas y paquetes bmov / ******0030'],
+        Sueldos: ['diego', 'catalina', 'rosario', 'erika', 'catarina', 'maria gua', 'karla', 'lupita', 'jovita', 'recargas y paquetes bmov / ******0030'],
         Tecnologia: ['openai', 'claude', 'whaticket', 'hostinger', 'payu *google cloud', 'tripo ai'],
         Local: ['local', 'renta', 'valeria'], 
         Deudas: ['saldos vencidos'], 

--- a/public/admon/sw.js
+++ b/public/admon/sw.js
@@ -4,10 +4,10 @@
 //  - JS/CSS/Img estáticos: cache-first con actualización en background
 //  - API/Firestore/Firebase: passthrough (sin cachear)
 
-// v8 (2026-05-18): Font Awesome también se mueve a copia local
-// (js/vendor/fontawesome/). Antes venía de cdnjs y los iconos no cargaban
-// en producción. Bump fuerza refresh.
-const CACHE_VERSION = 'admon-v8';
+// v9 (2026-05-18): se añade 'jovita' a las reglas de auto-categorización
+// como Sueldos en utils.js (autoCategorizeWithRulesOnly). Bump fuerza
+// refresh de utils.js cacheado por clientes.
+const CACHE_VERSION = 'admon-v9';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const PAGE_CACHE = `${CACHE_VERSION}-pages`;
 


### PR DESCRIPTION
- utils.js: agrega 'jovita' al array de keywords de auto-categorizacion Sueldos, para que futuras importaciones BBVA con conceptos que mencionen jovita caigan directo a Sueldos sin intervencion manual
- sw.js bump admon-v8 -> admon-v9 para forzar refresh de utils.js cacheado por clientes existentes