### PR TITLE
admon: reglas de categorizacion editables desde la UI + fix raiz SPEI

### DIFF
--- a/public/admon/index.html
+++ b/public/admon/index.html
@@ -155,6 +155,7 @@
                     <button id="add-manual-btn" class="btn btn-outline"><i class="fas fa-plus"></i> Agregar Gasto/Ingreso</button>
                     <button id="reconcile-btn" class="btn btn-outline" title="Conciliar saldo contra BBVA"><i class="fas fa-balance-scale"></i> Conciliar BBVA</button>
                     <button id="remove-duplicates-btn" class="btn btn-outline" title="Eliminar sólo duplicados exactos (firma estricta)"><i class="fas fa-clone"></i> Limpiar duplicados</button>
+                    <button id="rules-btn" class="btn btn-outline" title="Reglas de categorización automática (keyword → categoría)"><i class="fas fa-tags"></i> Reglas</button>
                     <button id="export-btn" class="btn btn-outline"><i class="fas fa-download"></i> Exportar</button>
                     <button id="delete-previous-month-btn" class="btn btn-outline btn-danger" style="background-color: var(--danger-light); border-color: transparent; color: var(--danger);"><i class="fas fa-calendar-minus"></i> Borrar Mes Anterior</button>
                     <button id="delete-current-month-btn" class="btn btn-outline btn-danger" style="background-color: var(--danger-light); border-color: transparent; color: var(--danger);"><i class="fas fa-calendar-times"></i> Borrar Mes Actual</button>

--- a/public/admon/js/handlers.js
+++ b/public/admon/js/handlers.js
@@ -360,6 +360,10 @@ export function initEventListeners() {
     const exportKpisBtn = document.getElementById('export-kpis-btn');
     if (exportKpisBtn) exportKpisBtn.addEventListener('click', handleExportKpis);
 
+    // Modal de reglas de categorizacion (keyword -> categoria, editable).
+    const rulesBtn = document.getElementById('rules-btn');
+    if (rulesBtn) rulesBtn.addEventListener('click', () => ui.openRulesModal());
+
     // Toggle de modo prueba (banner + botón). Lo conecta `ui-manager.js`
     // al renderizar el banner; nada que hacer aquí.
     

--- a/public/admon/js/main.js
+++ b/public/admon/js/main.js
@@ -61,6 +61,8 @@ function initializeAppUI() {
     services.listenForNotes(ui.renderNotes);
     // Configuración del saldo inicial (alimenta "Saldo BBVA Estimado" del Resumen)
     services.listenForBalanceConfig(onDataChange);
+    // Reglas de categorización dinámicas (modal "Reglas"; fallback a código)
+    services.listenForCategorizationRules(onDataChange);
 
     ui.renderMonthFilter();
     

--- a/public/admon/js/services.js
+++ b/public/admon/js/services.js
@@ -387,6 +387,44 @@ export function setupOrdersListener(onDataChange) {
 }
 
 
+// --- REGLAS DE CATEGORIZACIÓN (editables desde el modal "Reglas") ---
+
+/**
+ * Escucha el doc `admin_data/categorization_rules`. Si existe y trae un
+ * array `rules` válido, lo vuelca a state.categorizationRules (las reglas
+ * dinámicas mandan). Si no existe, deja null → utils.js usa las
+ * DEFAULT_KEYWORD_RULES hardcodeadas como fallback.
+ */
+export function listenForCategorizationRules(onDataChange) {
+    const ref = doc(db, "admin_data", "categorization_rules");
+    return onSnapshot(ref, (snap) => {
+        if (snap.exists() && Array.isArray(snap.data().rules)) {
+            state.categorizationRules = snap.data().rules;
+        } else {
+            state.categorizationRules = null;
+        }
+        onDataChange();
+    }, (error) => console.error("Categorization Rules Listener Error:", error));
+}
+
+/**
+ * Reemplaza el set completo de reglas dinámicas. El array debe venir ya
+ * validado por la UI (keywords normalizadas a minúsculas, >= 3 chars).
+ * El listener actualiza state automáticamente tras el guardado.
+ *
+ * @param {Array<{keyword:string, category:string}>} rules
+ * @returns {Promise<number>} cantidad de reglas guardadas
+ */
+export async function saveCategorizationRules(rules) {
+    if (!Array.isArray(rules)) throw new Error('rules debe ser un array');
+    await setDoc(doc(db, "admin_data", "categorization_rules"), {
+        version: 1,
+        rules,
+        updatedAt: Timestamp.now()
+    });
+    return rules.length;
+}
+
 // --- OPERACIONES CRUD ---
 
 export async function saveExpense(expenseData, originalCategory) {
@@ -401,9 +439,20 @@ export async function saveExpense(expenseData, originalCategory) {
         // Persistir el cambio manual de categoría POR COMERCIO (parte antes de "/").
         // Asi una sola categorizacion aplica a todos los movimientos del mismo
         // comercio aunque cada uno tenga AUT/RFC distinto en el concepto.
+        //
+        // FIX RAIZ (2026-05-27): los conceptos de transferencia bancaria NO
+        // generan override de comercio. Su "comercio" (ej. "spei enviado albo")
+        // es el BANCO, no el destinatario — un override ahí captura TODAS las
+        // transferencias de ese banco sin importar a quién van (causa del bug
+        // albo→Alex que mandaba transferencias de chris y jovita a Alex).
+        // El movimiento individual SÍ conserva la categoría que el usuario
+        // eligió; sólo se omite la regla automática de comercio.
+        const BANK_TRANSFER_PREFIXES = ['spei enviado', 'spei recibido', 'pago cuenta de tercero', 'spei retornado'];
+        const isBankTransfer = merchantKey && BANK_TRANSFER_PREFIXES.some(p => merchantKey.startsWith(p));
+
         if (newCategory && newCategory !== 'SinCategorizar' && categoryChanged && merchantKey) {
             const ruleBasedCategory = autoCategorizeWithRulesOnly(concept);
-            if (newCategory !== ruleBasedCategory) {
+            if (newCategory !== ruleBasedCategory && !isBankTransfer) {
                 await setDoc(doc(db, "manualCategories", hashCode(merchantKey)), {
                     concept: merchantKey,
                     category: newCategory,

--- a/public/admon/js/state.js
+++ b/public/admon/js/state.js
@@ -76,7 +76,18 @@ export const state = {
     openingDate: '2026-03-01',
     isConfigured: false,
     updatedAt: null
-  }
+  },
+
+  /**
+   * Reglas de categorización por keyword, editables desde la UI (modal
+   * "Reglas"). Vienen del doc Firestore `admin_data/categorization_rules`.
+   * Formato: [{ keyword: 'jovita', category: 'Sueldos' }, ...] — el orden
+   * del array es el orden de evaluación (primera que matchea gana).
+   *
+   * null = el doc no existe todavía → utils.js usa las reglas hardcodeadas
+   * (DEFAULT_KEYWORD_RULES) como fallback. Imposible quedarse sin reglas.
+   */
+  categorizationRules: null
 };
 
 export const charts = { 

--- a/public/admon/js/ui-manager.js
+++ b/public/admon/js/ui-manager.js
@@ -1,5 +1,5 @@
 import { elements, state } from './state.js';
-import { formatCurrency, autoCategorize, capitalize, getAllCategories, getExpenseParts, computePayrollFromChecador, getChecadorPeriodLabel, getChecadorPeriodRange } from './utils.js';
+import { formatCurrency, autoCategorize, capitalize, getAllCategories, getExpenseParts, computePayrollFromChecador, getChecadorPeriodLabel, getChecadorPeriodRange, getActiveKeywordRules, categorizeWithTrace } from './utils.js';
 import * as services from './services.js';
 import { isTestMode, setTestMode, isDevMode, setDevMode, describeMode } from './config.js';
 
@@ -2819,6 +2819,219 @@ export function showDryRunReportModal(opts) {
                     $import.innerHTML = importLabel;
                 }
             });
+        }
+    });
+}
+
+// =============================================================================
+//  Modal "Reglas de categorización" — tabla editable + probador de conceptos
+// =============================================================================
+
+/**
+ * Abre el modal de gestión de reglas keyword → categoría.
+ *
+ * - La tabla muestra las reglas ACTIVAS: las de Firestore si existen
+ *   (admin_data/categorization_rules), o las hardcodeadas como semilla.
+ * - El orden de las filas ES la prioridad de evaluación (primera que
+ *   matchea gana). Flechas ↑↓ para reordenar.
+ * - "Guardar reglas" persiste el array completo en Firestore. A partir de
+ *   ese momento las reglas dinámicas mandan sobre las de código.
+ * - El probador muestra qué categoría recibiría un concepto Y POR QUÉ
+ *   (override exacto / override de comercio / regla / nada).
+ */
+export function openRulesModal() {
+    // Copia de trabajo local — sólo se persiste al dar "Guardar reglas".
+    const working = getActiveKeywordRules().map(r => ({
+        keyword: String(r.keyword || ''),
+        category: String(r.category || 'SinCategorizar')
+    }));
+    const usingFirestore = Array.isArray(state.categorizationRules) && state.categorizationRules.length > 0;
+
+    const esc = (s) => String(s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+    const body = `
+        <div style="display:grid;gap:14px;max-width:680px;">
+            <div style="border:1px solid var(--border-color);border-radius:10px;padding:12px;">
+                <div style="font-size:11px;text-transform:uppercase;font-weight:700;color:var(--text-secondary);margin-bottom:8px;">
+                    <i class="fas fa-vial"></i> Probador de conceptos
+                </div>
+                <div style="display:flex;gap:8px;">
+                    <input type="text" id="rules-tester-input" class="modal-input" style="flex:1;"
+                           placeholder="Pega un concepto, ej: SPEI ENVIADO albo / 0074313326 721 0506260Jovita">
+                    <button type="button" id="rules-tester-btn" class="btn btn-outline">Probar</button>
+                </div>
+                <div id="rules-tester-result" style="font-size:13px;margin-top:8px;"></div>
+            </div>
+
+            <div style="border:1px solid var(--border-color);border-radius:10px;padding:12px;">
+                <div style="font-size:11px;text-transform:uppercase;font-weight:700;color:var(--text-secondary);margin-bottom:4px;">
+                    <i class="fas fa-tags"></i> Reglas — el orden es la prioridad (la primera que matchea gana)
+                </div>
+                <div style="font-size:11px;color:var(--text-secondary);margin-bottom:10px;">
+                    Aplican a <strong>cargos</strong> en futuras importaciones; no re-categorizan movimientos ya guardados.
+                    Fuente actual: <strong>${usingFirestore ? 'Firestore (editadas desde aquí)' : 'código (semilla — al guardar pasan a Firestore)'}</strong>.
+                </div>
+                <div id="rules-table-wrap" style="max-height:320px;overflow-y:auto;border:1px solid var(--border-color);border-radius:8px;"></div>
+                <button type="button" id="rules-add-btn" class="btn btn-outline btn-sm" style="margin-top:10px;">
+                    <i class="fas fa-plus"></i> Agregar regla
+                </button>
+            </div>
+        </div>`;
+
+    showModal({
+        title: 'Reglas de categorización',
+        body,
+        confirmText: 'Guardar reglas',
+        showCancel: true,
+        onConfirm: async () => {
+            // Validación + normalización
+            const clean = [];
+            const seen = new Set();
+            const problems = [];
+            working.forEach((r, i) => {
+                const kw = String(r.keyword || '').toLowerCase().replace(/\s+/g, ' ').trim();
+                const cat = String(r.category || '').trim();
+                if (!kw) { problems.push(`Fila ${i + 1}: keyword vacía`); return; }
+                if (kw.length < 3) { problems.push(`Fila ${i + 1}: "${kw}" es muy corta (mínimo 3 caracteres)`); return; }
+                if (!cat) { problems.push(`Fila ${i + 1}: sin categoría`); return; }
+                if (seen.has(kw)) { problems.push(`Fila ${i + 1}: keyword "${kw}" repetida (gana la primera)`); return; }
+                seen.add(kw);
+                clean.push({ keyword: kw, category: cat });
+            });
+
+            if (problems.length > 0) {
+                showToast(`No se guardó: ${problems[0]}${problems.length > 1 ? ` (+${problems.length - 1} más, ver consola)` : ''}`, 'error');
+                console.warn('Problemas de validación en reglas:', problems);
+                return; // el modal queda abierto para corregir
+            }
+            if (clean.length === 0) {
+                showToast('No puedes guardar una lista vacía de reglas', 'error');
+                return;
+            }
+
+            try {
+                const count = await services.saveCategorizationRules(clean);
+                showToast(`${count} reglas guardadas`, 'success');
+                showModal({ show: false });
+            } catch (err) {
+                console.error('Error guardando reglas:', err);
+                showToast('No se pudieron guardar las reglas', 'error');
+            }
+        },
+        onModalOpen: () => {
+            const wrap = document.getElementById('rules-table-wrap');
+
+            const buildCategoryOptions = (selected) => {
+                const cats = getAllCategories();
+                if (selected && !cats.includes(selected)) cats.push(selected);
+                return cats.map(c => `<option value="${esc(c)}" ${c === selected ? 'selected' : ''}>${esc(c)}</option>`).join('');
+            };
+
+            const render = () => {
+                wrap.innerHTML = `
+                    <table style="width:100%;border-collapse:collapse;font-size:12px;">
+                        <thead style="position:sticky;top:0;background:var(--bg-card);z-index:1;">
+                            <tr>
+                                <th style="padding:6px;width:30px;">#</th>
+                                <th style="padding:6px;width:56px;"></th>
+                                <th style="padding:6px;text-align:left;">Keyword (contiene)</th>
+                                <th style="padding:6px;text-align:left;width:170px;">Categoría</th>
+                                <th style="padding:6px;width:36px;"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            ${working.map((r, i) => `
+                                <tr style="border-top:1px solid var(--border-color);">
+                                    <td style="padding:4px 6px;color:var(--text-secondary);text-align:center;">${i + 1}</td>
+                                    <td style="padding:4px 2px;white-space:nowrap;">
+                                        <button type="button" class="btn btn-sm rule-up" data-idx="${i}" ${i === 0 ? 'disabled' : ''} style="padding:2px 6px;">↑</button>
+                                        <button type="button" class="btn btn-sm rule-down" data-idx="${i}" ${i === working.length - 1 ? 'disabled' : ''} style="padding:2px 6px;">↓</button>
+                                    </td>
+                                    <td style="padding:4px 6px;">
+                                        <input type="text" class="modal-input rule-kw" data-idx="${i}" value="${esc(r.keyword)}" style="width:100%;padding:5px 8px;font-size:12px;">
+                                    </td>
+                                    <td style="padding:4px 6px;">
+                                        <select class="modal-input rule-cat" data-idx="${i}" style="width:100%;padding:5px 8px;font-size:12px;">
+                                            ${buildCategoryOptions(r.category)}
+                                        </select>
+                                    </td>
+                                    <td style="padding:4px 6px;text-align:center;">
+                                        <button type="button" class="btn btn-sm rule-del" data-idx="${i}" style="color:var(--danger);padding:2px 8px;"><i class="fas fa-trash"></i></button>
+                                    </td>
+                                </tr>`).join('')}
+                        </tbody>
+                    </table>`;
+            };
+
+            // Delegación de eventos: inputs escriben directo a `working`,
+            // mover/borrar mutan y re-renderizan.
+            wrap.addEventListener('input', (e) => {
+                const kw = e.target.closest('.rule-kw');
+                if (kw) working[parseInt(kw.dataset.idx)].keyword = kw.value;
+            });
+            wrap.addEventListener('change', (e) => {
+                const cat = e.target.closest('.rule-cat');
+                if (cat) working[parseInt(cat.dataset.idx)].category = cat.value;
+            });
+            wrap.addEventListener('click', (e) => {
+                const up = e.target.closest('.rule-up');
+                const down = e.target.closest('.rule-down');
+                const del = e.target.closest('.rule-del');
+                if (up) {
+                    const i = parseInt(up.dataset.idx);
+                    [working[i - 1], working[i]] = [working[i], working[i - 1]];
+                    render();
+                } else if (down) {
+                    const i = parseInt(down.dataset.idx);
+                    [working[i], working[i + 1]] = [working[i + 1], working[i]];
+                    render();
+                } else if (del) {
+                    working.splice(parseInt(del.dataset.idx), 1);
+                    render();
+                }
+            });
+
+            document.getElementById('rules-add-btn').addEventListener('click', () => {
+                working.push({ keyword: '', category: 'SinCategorizar' });
+                render();
+                // Scroll al fondo y enfocar la keyword nueva
+                wrap.scrollTop = wrap.scrollHeight;
+                const inputs = wrap.querySelectorAll('.rule-kw');
+                if (inputs.length) inputs[inputs.length - 1].focus();
+            });
+
+            // --- Probador ---
+            const $in = document.getElementById('rules-tester-input');
+            const $btn = document.getElementById('rules-tester-btn');
+            const $out = document.getElementById('rules-tester-result');
+
+            const runTest = () => {
+                const value = $in.value.trim();
+                if (!value) { $out.innerHTML = ''; return; }
+                const t = categorizeWithTrace(value);
+                let html = '';
+                if (t.mechanism === 'override-exacto') {
+                    html = `→ <strong>${esc(t.category)}</strong> por <span style="color:#d97706;font-weight:600;">OVERRIDE EXACTO</span> del concepto completo.<br>
+                        <span style="font-size:11px;color:var(--text-secondary);">Las reglas no aplican mientras exista ese override en manualCategories.</span>`;
+                } else if (t.mechanism === 'override-merchant') {
+                    html = `→ <strong>${esc(t.category)}</strong> por <span style="color:#d97706;font-weight:600;">OVERRIDE DE COMERCIO</span> "<code>${esc(t.detail)}</code>".<br>
+                        <span style="font-size:11px;color:var(--text-secondary);">Este override gana sobre las reglas. Si está mal, hay que borrarlo de manualCategories.</span>`;
+                } else if (t.mechanism === 'regla') {
+                    html = `→ <strong style="color:var(--success);">${esc(t.category)}</strong> por la regla "<code>${esc(t.detail)}</code>" (posición ${t.position}, fuente: ${t.source === 'firestore' ? 'Firestore' : 'código'}).`;
+                } else {
+                    html = `→ <strong>SinCategorizar</strong> — ningún override ni regla matchea.`;
+                }
+                $out.innerHTML = html;
+            };
+
+            $btn.addEventListener('click', runTest);
+            $in.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') { e.preventDefault(); runTest(); }
+            });
+
+            render();
         }
     });
 }

--- a/public/admon/js/utils.js
+++ b/public/admon/js/utils.js
@@ -198,26 +198,133 @@ export function autoCategorize(concept) {
     return autoCategorizeWithRulesOnly(concept);
 }
 
+/**
+ * Reglas de categorización por keyword HARDCODEADAS — lista plana ordenada.
+ * El orden del array es el orden de evaluación: la primera keyword que
+ * matchea gana (por eso 'chris' va antes que 'alex': una transferencia
+ * "transf a chris" cae en Chris aunque después hubiera matcheado otra).
+ *
+ * Desde 2026-05-27 estas reglas son el SEED y FALLBACK del sistema dinámico:
+ * si existe el doc Firestore `admin_data/categorization_rules`, ese manda
+ * (editable desde el modal "Reglas" de la UI). Si no existe o falla la
+ * lectura, se usan estas. El orden aquí replica el orden del objeto `rules`
+ * histórico (categoría por categoría).
+ */
+export const DEFAULT_KEYWORD_RULES = [
+    { keyword: 'xciento', category: 'Ganancia' },
+    { keyword: 'chris', category: 'Chris' },
+    { keyword: 'moises', category: 'Chris' },
+    { keyword: 'wm max llc', category: 'Chris' },
+    { keyword: 'stori', category: 'Chris' },
+    { keyword: 'jessica', category: 'Chris' },
+    { keyword: 'yannine', category: 'Chris' },
+    { keyword: 'recargas y paquetes bmov / ******6530', category: 'Chris' },
+    { keyword: 'recargas y paquetes bmov / ******7167', category: 'Chris' },
+    { keyword: 'carniceria las pradera', category: 'Chris' },
+    { keyword: 'minisuper natalia', category: 'Chris' },
+    { keyword: 'temu', category: 'Chris' },
+    { keyword: 'alsuper plus mezquital', category: 'Chris' },
+    { keyword: 'alsuper plus d arrieta', category: 'Chris' },
+    { keyword: 'fruteria alvarez', category: 'Chris' },
+    { keyword: 'alex', category: 'Alex' },
+    { keyword: 'bolt', category: 'Alex' },
+    { keyword: 'retiro sin tarjeta / ******0670', category: 'Alex' },
+    { keyword: 'facebook', category: 'Publicidad' },
+    { keyword: 'material', category: 'Material' },
+    { keyword: 'raza', category: 'Material' },
+    { keyword: 'c00008749584', category: 'Material' },
+    { keyword: 'acrilico', category: 'Material' },
+    { keyword: 'mercadolibre', category: 'Material' },
+    { keyword: 'psa computo', category: 'Material' },
+    { keyword: 'guias', category: 'Envios' },
+    { keyword: 'diego', category: 'Sueldos' },
+    { keyword: 'catalina', category: 'Sueldos' },
+    { keyword: 'rosario', category: 'Sueldos' },
+    { keyword: 'erika', category: 'Sueldos' },
+    { keyword: 'catarina', category: 'Sueldos' },
+    { keyword: 'maria gua', category: 'Sueldos' },
+    { keyword: 'karla', category: 'Sueldos' },
+    { keyword: 'lupita', category: 'Sueldos' },
+    { keyword: 'jovita', category: 'Sueldos' },
+    { keyword: 'recargas y paquetes bmov / ******0030', category: 'Sueldos' },
+    { keyword: 'openai', category: 'Tecnologia' },
+    { keyword: 'claude', category: 'Tecnologia' },
+    { keyword: 'whaticket', category: 'Tecnologia' },
+    { keyword: 'hostinger', category: 'Tecnologia' },
+    { keyword: 'payu *google cloud', category: 'Tecnologia' },
+    { keyword: 'tripo ai', category: 'Tecnologia' },
+    { keyword: 'local', category: 'Local' },
+    { keyword: 'renta', category: 'Local' },
+    { keyword: 'valeria', category: 'Local' },
+    { keyword: 'saldos vencidos', category: 'Deudas' },
+    { keyword: 'devolucion', category: 'Devoluciones' },
+    { keyword: 'interes', category: 'GastosFinancieros' },
+    { keyword: 'comision', category: 'GastosFinancieros' }
+];
+
+/**
+ * Devuelve las reglas activas: las dinámicas de Firestore si existen
+ * (state.categorizationRules, alimentado por listenForCategorizationRules),
+ * o las hardcodeadas como fallback.
+ */
+export function getActiveKeywordRules() {
+    const dyn = state.categorizationRules;
+    return (Array.isArray(dyn) && dyn.length > 0) ? dyn : DEFAULT_KEYWORD_RULES;
+}
+
 export function autoCategorizeWithRulesOnly(concept) {
     const lowerConcept = String(concept).toLowerCase().replace(/\s+/g, ' ');
-    const rules = {
-        Ganancia: ['xciento'],
-        Chris: ['chris', 'moises', 'wm max llc', 'stori', 'jessica', 'yannine', 'recargas y paquetes bmov / ******6530', 'recargas y paquetes bmov / ******7167', 'carniceria las pradera', 'minisuper natalia', 'temu', 'alsuper plus mezquital', 'alsuper plus d arrieta', 'fruteria alvarez'],
-        Alex: ['alex', 'bolt', 'retiro sin tarjeta / ******0670'],
-        Publicidad: ['facebook'],
-        Material: ['material', 'raza', 'c00008749584', 'acrilico', 'mercadolibre', 'psa computo'],
-        Envios: ['guias'], 
-        Sueldos: ['diego', 'catalina', 'rosario', 'erika', 'catarina', 'maria gua', 'karla', 'lupita', 'jovita', 'recargas y paquetes bmov / ******0030'],
-        Tecnologia: ['openai', 'claude', 'whaticket', 'hostinger', 'payu *google cloud', 'tripo ai'],
-        Local: ['local', 'renta', 'valeria'], 
-        Deudas: ['saldos vencidos'], 
-        Devoluciones: ['devolucion'],
-        GastosFinancieros: ['interes', 'comision']
-    };
-    for (const category in rules) {
-        if (rules[category].some(keyword => lowerConcept.includes(keyword))) return category;
+    const rules = getActiveKeywordRules();
+    for (const rule of rules) {
+        if (rule && rule.keyword && lowerConcept.includes(rule.keyword)) {
+            return rule.category;
+        }
     }
     return 'SinCategorizar';
+}
+
+/**
+ * Versión instrumentada de autoCategorize para el PROBADOR del modal Reglas.
+ * Devuelve no sólo la categoría sino el MECANISMO que la decidió, para que
+ * el usuario pueda autodiagnosticar "¿por qué este concepto cae ahí?".
+ *
+ * @param {string} concept
+ * @returns {{ category:string, mechanism:'override-exacto'|'override-merchant'|'regla'|'ninguno',
+ *             detail?:string, position?:number, source?:'firestore'|'codigo' }}
+ */
+export function categorizeWithTrace(concept) {
+    // Espeja EXACTAMENTE la cascada de autoCategorize().
+    const lowerConcept = String(concept).toLowerCase();
+    if (state.manualCategories.has(lowerConcept)) {
+        return {
+            category: state.manualCategories.get(lowerConcept),
+            mechanism: 'override-exacto',
+            detail: lowerConcept
+        };
+    }
+    const merchantKey = extractMerchantKey(concept);
+    if (merchantKey && state.manualCategories.has(merchantKey)) {
+        return {
+            category: state.manualCategories.get(merchantKey),
+            mechanism: 'override-merchant',
+            detail: merchantKey
+        };
+    }
+    const normalized = String(concept).toLowerCase().replace(/\s+/g, ' ');
+    const rules = getActiveKeywordRules();
+    for (let i = 0; i < rules.length; i++) {
+        const rule = rules[i];
+        if (rule && rule.keyword && normalized.includes(rule.keyword)) {
+            return {
+                category: rule.category,
+                mechanism: 'regla',
+                detail: rule.keyword,
+                position: i + 1,
+                source: (Array.isArray(state.categorizationRules) && state.categorizationRules.length > 0) ? 'firestore' : 'codigo'
+            };
+        }
+    }
+    return { category: 'SinCategorizar', mechanism: 'ninguno' };
 }
 
 /**

--- a/public/admon/sw.js
+++ b/public/admon/sw.js
@@ -4,10 +4,12 @@
 //  - JS/CSS/Img estáticos: cache-first con actualización en background
 //  - API/Firestore/Firebase: passthrough (sin cachear)
 
-// v10 (2026-05-27): agrega exportacion de KPIs a Excel (3 hojas: KPIs
-// Diarios + Resumen Mensual + Por Cuenta Meta) con boton en pestana KPI's.
-// Bump fuerza refresh de handlers.js, services.js e index.html cacheados.
-const CACHE_VERSION = 'admon-v10';
+// v11 (2026-05-27): reglas de categorizacion editables desde la UI (modal
+// "Reglas" con tabla + probador de conceptos; doc Firestore
+// admin_data/categorization_rules con fallback a reglas hardcodeadas) y
+// fix raiz: las transferencias bancarias (spei enviado/recibido, pago
+// cuenta de tercero) ya no generan overrides de comercio al recategorizar.
+const CACHE_VERSION = 'admon-v11';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const PAGE_CACHE = `${CACHE_VERSION}-pages`;
 


### PR DESCRIPTION
- Nuevo modal 'Reglas' (boton en barra de Datos): tabla editable de keyword -> categoria con orden de prioridad (arriba/abajo, agregar, borrar) + probador de conceptos que muestra que categoria recibiria un concepto y por que mecanismo (override exacto / override de comercio / regla con posicion / nada)
- Reglas dinamicas en Firestore admin_data/categorization_rules; las hardcodeadas de utils.js quedan como semilla y fallback (dia 1 sin guardar = comportamiento identico)
- utils.js: DEFAULT_KEYWORD_RULES plana ordenada + getActiveKeywordRules
  + categorizeWithTrace para el probador
- services.js: listenForCategorizationRules + saveCategorizationRules
- FIX RAIZ: las transferencias bancarias (spei enviado/recibido, pago cuenta de tercero, spei retornado) ya no generan overrides de comercio al recategorizar a mano — causa del bug albo->Alex
- sw.js bump admon-v10 -> admon-v11