### PR TITLE
meta-ads: endpoint region-report (gasto por campana + mapa ad->campana)

### DIFF
--- a/server/meta/metaAdsRoutes.js
+++ b/server/meta/metaAdsRoutes.js
@@ -386,76 +386,50 @@ router.post('/sync-kpis', asyncHandler(async (req, res) => {
     });
 }));
 
+// ===================== REPORTE POR REGION (campanas: gasto + atribucion) =====================
+
 /**
- * GET /api/meta-ads/campaign-spend
- * Gasto de Meta Ads desglosado POR CAMPAÑA (nombre + spend) y total diario,
- * en un rango de fechas. Suma todas las cuentas configuradas (mismas que los KPIs).
- * No escribe en Firestore: es solo lectura para mostrar/consumir desde otras apps.
+ * POST /api/meta-ads/region-report
  *
- * Query params opcionales: date_from, date_to (YYYY-MM-DD), accountId. Default: mes actual.
- * Respuesta: { success, dateFrom, dateTo, accountIds, total,
- *              campaigns:[{campaign_name, spend}], daily:[{date, spend}], errors? }
+ * Devuelve lo necesario para la pestana "Campanas" del admon: gasto por
+ * campana de las 6 cuentas KPI en un rango, y (si el cliente manda adIds)
+ * el mapa adId->campana para atribuir las ventas de pedidos.
+ *
+ * Body: { date_from?, date_to?, adIds?: string[] }
+ *   - date_from/date_to: YYYY-MM-DD (default: mes actual)
+ *   - adIds: lista de attributedAdId distintos sacados de pedidos pagados
+ *
+ * Respuesta: {
+ *   success, dateFrom, dateTo, accountIds,
+ *   campaigns: [{ accountId, campaignId, campaignName, spend }],
+ *   adToCampaign: { [adId]: { campaignId, campaignName } },
+ *   errors?
+ * }
+ *
+ * El token Meta queda server-side (no se expone al cliente).
  */
-router.get('/campaign-spend', asyncHandler(async (req, res) => {
-    // 1. Resolver cuentas (mismo patrón que /sync-kpis).
-    let accountIds = await svc.getKpiAccountIds();
+router.post('/region-report', asyncHandler(async (req, res) => {
+    const accountIds = await svc.getKpiAccountIds();
     if (accountIds.length === 0) {
-        const settings = await svc.getActiveAccount();
-        const fallback = req.query.accountId || settings?.activeAccountId;
-        if (fallback) accountIds = [String(fallback).replace('act_', '')];
-    }
-    if (accountIds.length === 0) {
-        return res.status(400).json({
-            success: false,
-            error: 'No hay cuentas Meta configuradas. Define settings.kpiAccountIds o una cuenta activa.'
-        });
+        return res.status(400).json({ success: false, error: 'No hay cuentas KPI configuradas (settings.kpiAccountIds).' });
     }
 
-    // 2. Rango de fechas (default: mes actual).
     const today = new Date();
     const firstOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
-    const dateFrom = req.query.date_from || firstOfMonth.toISOString().split('T')[0];
-    const dateTo   = req.query.date_to   || today.toISOString().split('T')[0];
+    const dateFrom = req.body?.date_from || firstOfMonth.toISOString().split('T')[0];
+    const dateTo   = req.body?.date_to   || today.toISOString().split('T')[0];
+    const adIds = Array.isArray(req.body?.adIds) ? req.body.adIds : [];
 
-    // 3. Por cada cuenta: insights por campaña + gasto diario. Acumular.
-    const campaignMap = new Map(); // campaign_name -> spend
-    const dailyMap = new Map();    // fecha -> spend
-    const errors = [];
-
-    for (const accId of accountIds) {
-        try {
-            const rows = await svc.getInsightsByLevel(accId, 'campaign', dateFrom, dateTo);
-            for (const r of rows) {
-                const name = r.campaign_name || r.campaign_id || '(sin nombre)';
-                const spend = Number(r.spend) || 0;
-                if (spend <= 0) continue;
-                campaignMap.set(name, (campaignMap.get(name) || 0) + spend);
-            }
-            const daily = await svc.getDailySpend(accId, dateFrom, dateTo);
-            for (const d of daily) {
-                if (!d.date) continue;
-                dailyMap.set(d.date, (dailyMap.get(d.date) || 0) + (Number(d.spend) || 0));
-            }
-        } catch (err) {
-            const msg = err.response?.data?.error?.message || err.message;
-            errors.push({ accountId: accId, error: msg });
-            console.error(`Meta campaign-spend error for account ${accId}:`, err.response?.data || err.message);
-        }
-    }
-
-    const round2 = n => Math.round(n * 100) / 100;
-    const campaigns = [...campaignMap.entries()]
-        .map(([campaign_name, spend]) => ({ campaign_name, spend: round2(spend) }))
-        .sort((a, b) => b.spend - a.spend);
-    const daily = [...dailyMap.entries()]
-        .map(([date, spend]) => ({ date, spend: round2(spend) }))
-        .sort((a, b) => a.date.localeCompare(b.date));
-    const total = round2(campaigns.reduce((s, c) => s + c.spend, 0));
+    const { campaigns, errors } = await svc.getCampaignSpendForAccounts(accountIds, dateFrom, dateTo);
+    const adToCampaign = adIds.length ? await svc.resolveAdsToCampaigns(adIds) : {};
 
     res.json({
         success: true,
         dateFrom, dateTo, accountIds,
-        total, campaigns, daily,
+        campaigns,
+        adToCampaign,
+        adsResolved: Object.keys(adToCampaign).length,
+        adsRequested: [...new Set(adIds.filter(Boolean).map(String))].length,
         errors: errors.length ? errors : undefined
     });
 }));

--- a/server/meta/metaAdsService.js
+++ b/server/meta/metaAdsService.js
@@ -392,6 +392,72 @@ async function getDailySpend(accountId, dateFrom, dateTo) {
     }));
 }
 
+// ===================== REPORTE POR REGION (gasto por campana + mapa ad->campana) =====================
+
+/**
+ * Gasto por campana de varias cuentas en un rango. Reusa getInsightsByLevel
+ * a nivel 'campaign' (ya paginado) por cada cuenta. Si una cuenta falla, se
+ * registra el error y se continua con las demas.
+ *
+ * @param {string[]} accountIds  IDs limpios (sin act_)
+ * @param {string} dateFrom YYYY-MM-DD
+ * @param {string} dateTo   YYYY-MM-DD
+ * @returns {Promise<{campaigns:Array<{accountId,campaignId,campaignName,spend}>, errors:Array}>}
+ */
+async function getCampaignSpendForAccounts(accountIds, dateFrom, dateTo) {
+    const campaigns = [];
+    const errors = [];
+    for (const accId of accountIds) {
+        try {
+            const rows = await getInsightsByLevel(accId, 'campaign', dateFrom, dateTo);
+            rows.forEach(r => campaigns.push({
+                accountId: String(accId).replace('act_', ''),
+                campaignId: r.campaign_id,
+                campaignName: r.campaign_name,
+                spend: Number(r.spend) || 0
+            }));
+        } catch (err) {
+            errors.push({ accountId: accId, error: err.response?.data?.error?.message || err.message });
+        }
+    }
+    return { campaigns, errors };
+}
+
+/**
+ * Resuelve una lista de Ad IDs a su campana usando el batch-read de Meta
+ * (GET /?ids=ad1,ad2,...&fields=campaign{id,name}, max 50 por llamada).
+ * Los anuncios borrados o sin acceso simplemente no aparecen en el mapa.
+ *
+ * @param {string[]} adIds
+ * @returns {Promise<Object<string,{campaignId,campaignName}>>}
+ */
+async function resolveAdsToCampaigns(adIds) {
+    const map = {};
+    const unique = [...new Set((adIds || []).filter(Boolean).map(String))];
+    const BATCH = 50;
+    for (let i = 0; i < unique.length; i += BATCH) {
+        const batch = unique.slice(i, i + BATCH);
+        try {
+            // path '' -> https://graph.facebook.com/<ver>/?ids=...  (token global)
+            const resp = await metaGet('', { ids: batch.join(','), fields: 'campaign{id,name}' }, null);
+            for (const adId of Object.keys(resp || {})) {
+                const camp = resp[adId] && resp[adId].campaign;
+                if (camp) map[adId] = { campaignId: camp.id, campaignName: camp.name };
+            }
+        } catch (err) {
+            // Si el batch entero falla (un id invalido tumba la llamada),
+            // reintentamos uno por uno para no perder los demas.
+            for (const adId of batch) {
+                try {
+                    const one = await metaGet(adId, { fields: 'campaign{id,name}' }, null);
+                    if (one && one.campaign) map[adId] = { campaignId: one.campaign.id, campaignName: one.campaign.name };
+                } catch (_) { /* anuncio borrado/sin acceso: se omite */ }
+            }
+        }
+    }
+    return map;
+}
+
 // ===================== AUDIENCES / TARGETING =====================
 
 async function searchTargeting(query, type = 'adinterest', accountId) {
@@ -428,6 +494,8 @@ module.exports = {
     listCreatives, getCreative, createCreative, uploadAdImage, getCreativePreview,
     // Insights
     getInsights, getInsightsByLevel, getDailySpend,
+    // Reporte por region
+    getCampaignSpendForAccounts, resolveAdsToCampaigns,
     // Audiences
     searchTargeting, listCustomAudiences
 };


### PR DESCRIPTION
- getCampaignSpendForAccounts: gasto por campana de las 6 cuentas KPI reusando getInsightsByLevel('campaign') ya paginado
- resolveAdsToCampaigns: resuelve attributedAdId -> campana via batch-read de Meta (/?ids=...&fields=campaign{id,name}, 50 por llamada, fallback uno por uno; anuncios borrados se omiten)
- POST /api/meta-ads/region-report: junta ambos para la futura pestana Campanas del admon. Token server-side. Retro-compatible (solo agrega).