### PR TITLE
admon+meta: pestana Campanas (gasto/venta/ROAS por region)

### DIFF
--- a/public/admon/index.html
+++ b/public/admon/index.html
@@ -142,6 +142,7 @@
           <div class="tab" data-tab="sueldos"><i class="fas fa-file-invoice-dollar"></i> Sueldos</div>
           <div class="tab" data-tab="health"><i class="fas fa-heartbeat"></i> Salud Financiera</div>
           <div class="tab" data-tab="kpis"><i class="fas fa-tachometer-alt"></i> KPI's</div>
+          <div class="tab" data-tab="campaigns"><i class="fas fa-bullseye"></i> Campañas</div>
           <div class="tab" data-tab="notes"><i class="fas fa-sticky-note"></i> Notas</div>
         </div>
 
@@ -446,6 +447,27 @@
                </div>
              </div>
            </div>
+        </div>
+
+        <!-- Tab Content: Campañas (gasto/venta/ROAS por región) -->
+        <div class="tab-content" id="campaigns-tab">
+          <div class="card-body">
+            <div style="display:flex;gap:10px;align-items:flex-end;flex-wrap:wrap;margin-bottom:18px;">
+              <div class="form-group" style="margin:0;">
+                <label for="camp-date-from" style="font-size:12px;color:var(--text-secondary);">Desde</label>
+                <input type="date" id="camp-date-from" class="modal-input" style="width:auto;">
+              </div>
+              <div class="form-group" style="margin:0;">
+                <label for="camp-date-to" style="font-size:12px;color:var(--text-secondary);">Hasta</label>
+                <input type="date" id="camp-date-to" class="modal-input" style="width:auto;">
+              </div>
+              <button id="camp-calc-btn" class="btn"><i class="fas fa-calculator"></i> Calcular</button>
+              <button id="camp-regions-btn" class="btn btn-outline" title="Configurar regiones (keyword → región y override por campaña)"><i class="fas fa-map-marked-alt"></i> Regiones</button>
+            </div>
+            <div id="campaigns-content">
+              <p style="color:var(--text-secondary);">Elige un rango de fechas y pulsa <strong>Calcular</strong>.</p>
+            </div>
+          </div>
         </div>
 
         <!-- Tab Content: Notes (NUEVO) -->

--- a/public/admon/js/handlers.js
+++ b/public/admon/js/handlers.js
@@ -364,6 +364,12 @@ export function initEventListeners() {
     const rulesBtn = document.getElementById('rules-btn');
     if (rulesBtn) rulesBtn.addEventListener('click', () => ui.openRulesModal());
 
+    // Pestaña Campañas: calcular reporte + configurar regiones.
+    const campCalcBtn = document.getElementById('camp-calc-btn');
+    if (campCalcBtn) campCalcBtn.addEventListener('click', loadCampaignsReport);
+    const campRegionsBtn = document.getElementById('camp-regions-btn');
+    if (campRegionsBtn) campRegionsBtn.addEventListener('click', () => ui.openRegionsModal({ onSaved: loadCampaignsReport }));
+
     // Toggle de modo prueba (banner + botón). Lo conecta `ui-manager.js`
     // al renderizar el banner; nada que hacer aquí.
     
@@ -888,6 +894,19 @@ function handleTabClick(tab) {
             services.autoSyncMetaKpis().catch(() => {});
         }
     }
+
+    // Pestaña Campañas: sembrar fechas (últimos 30 días) y cargar una vez.
+    if (tab.dataset.tab === 'campaigns') {
+        const fromEl = document.getElementById('camp-date-from');
+        const toEl = document.getElementById('camp-date-to');
+        const fmt = d => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+        if (fromEl && toEl && (!fromEl.value || !toEl.value)) {
+            const today = new Date();
+            fromEl.value = fmt(new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000));
+            toEl.value = fmt(today);
+        }
+        if (!_campaignsLoadedOnce) { _campaignsLoadedOnce = true; loadCampaignsReport(); }
+    }
 }
 
 /**
@@ -1177,6 +1196,47 @@ async function handleExportKpis() {
             confirmText: 'Cerrar',
             showCancel: false
         });
+    }
+}
+
+// ============================================================================
+//  Pestaña Campañas — carga del reporte por región
+// ============================================================================
+
+let _campaignsLoadedOnce = false;
+
+/**
+ * Lee pedidos pagados del rango, saca sus attributedAdId, pide al backend el
+ * gasto por campaña + el mapa anuncio→campaña, y renderiza el reporte por
+ * región. Todo on-demand (no listener) — pesado pero acotado al rango.
+ */
+async function loadCampaignsReport() {
+    const out = document.getElementById('campaigns-content');
+    if (!out) return;
+    const dateFrom = document.getElementById('camp-date-from')?.value;
+    const dateTo   = document.getElementById('camp-date-to')?.value;
+    if (!dateFrom || !dateTo || dateFrom > dateTo) {
+        ui.showToast('Verifica las fechas (desde ≤ hasta)', 'warning');
+        return;
+    }
+
+    out.innerHTML = '<p><i class="fas fa-spinner fa-spin"></i> Cargando campañas y pedidos… (puede tardar unos segundos)</p>';
+    try {
+        const allPedidos = await services.fetchAllPedidos();
+        const inRange = allPedidos.filter(p => {
+            if (!(p.estatus === 'Pagado' || p.estatus === 'Fabricar')) return false;
+            if (!p.createdAt || typeof p.createdAt.toDate !== 'function') return false;
+            const d = p.createdAt.toDate();
+            const f = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
+            return f >= dateFrom && f <= dateTo;
+        });
+        const adIds = [...new Set(inRange.map(p => p.attributedAdId).filter(Boolean).map(String))];
+
+        const report = await services.fetchRegionReport({ dateFrom, dateTo, adIds });
+        ui.renderCampaignsReport(out, { report, paidInRange: inRange });
+    } catch (err) {
+        console.error('Error cargando reporte de campañas:', err);
+        out.innerHTML = `<p style="color:var(--danger);">Error: ${err.message}</p>`;
     }
 }
 

--- a/public/admon/js/main.js
+++ b/public/admon/js/main.js
@@ -63,6 +63,8 @@ function initializeAppUI() {
     services.listenForBalanceConfig(onDataChange);
     // Reglas de categorización dinámicas (modal "Reglas"; fallback a código)
     services.listenForCategorizationRules(onDataChange);
+    // Regiones de campañas (pestaña Campañas; fallback a semilla)
+    services.listenForCampaignRegions(onDataChange);
 
     ui.renderMonthFilter();
     

--- a/public/admon/js/services.js
+++ b/public/admon/js/services.js
@@ -425,6 +425,44 @@ export async function saveCategorizationRules(rules) {
     return rules.length;
 }
 
+// --- REGIONES DE CAMPAÑAS (pestaña Campañas) ---
+
+/** Escucha admin_data/campaign_regions → state.campaignRegions (null si no existe). */
+export function listenForCampaignRegions(onDataChange) {
+    const ref = doc(db, "admin_data", "campaign_regions");
+    return onSnapshot(ref, (snap) => {
+        state.campaignRegions = snap.exists() ? snap.data() : null;
+        onDataChange();
+    }, (error) => console.error("Campaign Regions Listener Error:", error));
+}
+
+/** Guarda la config de regiones (reglas keyword + overrides por campaña + default). */
+export async function saveCampaignRegions(config) {
+    await setDoc(doc(db, "admin_data", "campaign_regions"), {
+        rules: Array.isArray(config.rules) ? config.rules : [],
+        overrides: (config.overrides && typeof config.overrides === 'object') ? config.overrides : {},
+        defaultRegion: config.defaultRegion || 'Nacional',
+        updatedAt: Timestamp.now()
+    });
+}
+
+/**
+ * Llama al backend POST /api/meta-ads/region-report con el rango y los adIds
+ * (attributedAdId distintos de los pedidos pagados del rango). Devuelve
+ * { campaigns, adToCampaign, adsResolved, adsRequested, errors }.
+ */
+export async function fetchRegionReport({ dateFrom, dateTo, adIds }) {
+    const resp = await fetch('/api/meta-ads/region-report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ date_from: dateFrom, date_to: dateTo, adIds: adIds || [] })
+    });
+    if (!resp.ok) throw new Error('El servidor respondió ' + resp.status + ' (¿desplegaste el backend de region-report?)');
+    const data = await resp.json();
+    if (!data.success) throw new Error(data.error || 'region-report falló');
+    return data;
+}
+
 // --- OVERRIDES (manualCategories): gestión desde el modal Reglas ---
 
 /**

--- a/public/admon/js/state.js
+++ b/public/admon/js/state.js
@@ -87,7 +87,15 @@ export const state = {
    * null = el doc no existe todavía → utils.js usa las reglas hardcodeadas
    * (DEFAULT_KEYWORD_RULES) como fallback. Imposible quedarse sin reglas.
    */
-  categorizationRules: null
+  categorizationRules: null,
+
+  /**
+   * Configuración de regiones para la pestaña Campañas. Viene del doc
+   * Firestore `admin_data/campaign_regions`:
+   *   { rules:[{keyword,region}], overrides:{campaignId:region}, defaultRegion }
+   * null = no configurado → utils usa DEFAULT_REGION_RULES / 'Nacional'.
+   */
+  campaignRegions: null
 };
 
 export const charts = { 

--- a/public/admon/js/ui-manager.js
+++ b/public/admon/js/ui-manager.js
@@ -1,5 +1,5 @@
 import { elements, state } from './state.js';
-import { formatCurrency, autoCategorize, capitalize, getAllCategories, getExpenseParts, computePayrollFromChecador, getChecadorPeriodLabel, getChecadorPeriodRange, getActiveKeywordRules, categorizeWithTrace } from './utils.js';
+import { formatCurrency, autoCategorize, capitalize, getAllCategories, getExpenseParts, computePayrollFromChecador, getChecadorPeriodLabel, getChecadorPeriodRange, getActiveKeywordRules, categorizeWithTrace, buildRegionReport, getRegionConfig } from './utils.js';
 import * as services from './services.js';
 import { isTestMode, setTestMode, isDevMode, setDevMode, describeMode } from './config.js';
 
@@ -2839,6 +2839,256 @@ export function showDryRunReportModal(opts) {
  * - El probador muestra qué categoría recibiría un concepto Y POR QUÉ
  *   (override exacto / override de comercio / regla / nada).
  */
+// =============================================================================
+//  Pestaña Campañas — reporte gasto/venta/ROAS por región + modal de regiones
+// =============================================================================
+
+function escHtml(s) {
+    return String(s == null ? '' : s)
+        .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+// Campañas del último reporte renderizado (las usa el modal de regiones para
+// listar overrides por campaña).
+let _lastCampaignsForRegions = [];
+
+function campKpiBox(label, value, color) {
+    return `<div style="flex:1;min-width:120px;background:var(--bg-card);border:1px solid var(--border-color);border-radius:10px;padding:10px 12px;">
+        <div style="font-size:11px;color:var(--text-secondary);text-transform:uppercase;font-weight:600;">${label}</div>
+        <div style="font-size:18px;font-weight:800;color:${color || 'var(--text-primary)'};">${value}</div>
+    </div>`;
+}
+
+/**
+ * Renderiza el reporte por región dentro de `container`.
+ * @param {HTMLElement} container
+ * @param {{report:object, paidInRange:Array}} data
+ */
+export function renderCampaignsReport(container, { report, paidInRange }) {
+    const agg = buildRegionReport(report, paidInRange);
+    _lastCampaignsForRegions = agg.campaignsFull || [];
+
+    const money = (n) => formatCurrency(n);
+    const roas = (rev, sp) => sp > 0 ? (rev / sp).toFixed(2) + 'x' : '—';
+    const cpa  = (sp, ord) => ord > 0 ? money(sp / ord) : '—';
+
+    const adsNote = `${report.adsResolved ?? '?'}/${report.adsRequested ?? '?'} anuncios atribuidos`;
+    const errNote = report.errors ? ` · ⚠ ${report.errors.length} cuenta(s) con error (ver consola)` : '';
+
+    let html = `
+        <div style="display:flex;gap:10px;flex-wrap:wrap;margin-bottom:14px;">
+            ${campKpiBox('Gasto', money(agg.totals.spend), 'var(--danger)')}
+            ${campKpiBox('Venta atribuida', money(agg.totals.adRevenue), 'var(--success)')}
+            ${campKpiBox('ROAS global', roas(agg.totals.adRevenue, agg.totals.spend), 'var(--primary)')}
+            ${campKpiBox('Pedidos atribuidos', agg.totals.adOrders)}
+        </div>
+        <div style="font-size:11px;color:var(--text-secondary);margin-bottom:10px;">
+            Rango ${escHtml(report.dateFrom)} → ${escHtml(report.dateTo)} · ${adsNote}${errNote}.
+            La "venta atribuida" es un <strong>piso</strong>: sólo cuenta pedidos ligados a un anuncio. Orgánicos y anuncios borrados van aparte.
+        </div>
+        <div style="border:1px solid var(--border-color);border-radius:10px;overflow:hidden;">
+        <table style="width:100%;border-collapse:collapse;font-size:13px;">
+            <thead style="background:var(--bg-card);">
+                <tr>
+                    <th style="text-align:left;padding:8px 10px;">Región</th>
+                    <th style="text-align:right;padding:8px 10px;">Gasto</th>
+                    <th style="text-align:right;padding:8px 10px;">Venta</th>
+                    <th style="text-align:right;padding:8px 10px;">Pedidos</th>
+                    <th style="text-align:right;padding:8px 10px;">ROAS</th>
+                    <th style="text-align:right;padding:8px 10px;">CPA</th>
+                </tr>
+            </thead>
+            <tbody>`;
+
+    agg.regionList.forEach((r, ri) => {
+        html += `
+            <tr class="region-row" data-region="${ri}" style="cursor:pointer;border-top:1px solid var(--border-color);font-weight:600;">
+                <td style="padding:8px 10px;"><i class="fas fa-chevron-right region-caret" style="font-size:10px;transition:transform .15s;"></i> ${escHtml(r.region)} <span style="font-weight:400;color:var(--text-secondary);font-size:11px;">(${r.campaigns.length})</span></td>
+                <td style="text-align:right;padding:8px 10px;color:var(--danger);">${money(r.spend)}</td>
+                <td style="text-align:right;padding:8px 10px;color:var(--success);">${money(r.revenue)}</td>
+                <td style="text-align:right;padding:8px 10px;">${r.orders}</td>
+                <td style="text-align:right;padding:8px 10px;font-weight:700;color:${r.revenue >= r.spend ? 'var(--success)' : 'var(--danger)'};">${roas(r.revenue, r.spend)}</td>
+                <td style="text-align:right;padding:8px 10px;">${cpa(r.spend, r.orders)}</td>
+            </tr>
+            <tr class="region-detail" data-region="${ri}" style="display:none;">
+                <td colspan="6" style="padding:0;">
+                    <table style="width:100%;border-collapse:collapse;font-size:12px;background:rgba(127,127,127,0.04);">
+                        ${r.campaigns.map(c => `
+                            <tr style="border-top:1px solid var(--border-color);">
+                                <td style="padding:5px 10px 5px 28px;max-width:340px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${escHtml(c.name)}">${escHtml(c.name)}</td>
+                                <td style="text-align:right;padding:5px 10px;color:var(--danger);">${money(c.spend)}</td>
+                                <td style="text-align:right;padding:5px 10px;color:var(--success);">${money(c.revenue)}</td>
+                                <td style="text-align:right;padding:5px 10px;">${c.orders}</td>
+                                <td style="text-align:right;padding:5px 10px;">${roas(c.revenue, c.spend)}</td>
+                                <td style="text-align:right;padding:5px 10px;">${cpa(c.spend, c.orders)}</td>
+                            </tr>`).join('')}
+                    </table>
+                </td>
+            </tr>`;
+    });
+
+    html += `
+            <tr style="border-top:2px solid var(--border-color);">
+                <td style="padding:8px 10px;">Orgánico <span style="font-weight:400;color:var(--text-secondary);font-size:11px;">(venta sin anuncio)</span></td>
+                <td style="text-align:right;padding:8px 10px;">—</td>
+                <td style="text-align:right;padding:8px 10px;color:var(--success);">${money(agg.organic.revenue)}</td>
+                <td style="text-align:right;padding:8px 10px;">${agg.organic.orders}</td>
+                <td style="text-align:right;padding:8px 10px;">—</td>
+                <td style="text-align:right;padding:8px 10px;">—</td>
+            </tr>`;
+    if (agg.unattributed.orders > 0) {
+        html += `
+            <tr>
+                <td style="padding:8px 10px;color:var(--text-secondary);">Sin atribuir <span style="font-weight:400;font-size:11px;">(anuncio borrado)</span></td>
+                <td style="text-align:right;padding:8px 10px;">—</td>
+                <td style="text-align:right;padding:8px 10px;">${money(agg.unattributed.revenue)}</td>
+                <td style="text-align:right;padding:8px 10px;">${agg.unattributed.orders}</td>
+                <td style="text-align:right;padding:8px 10px;">—</td>
+                <td style="text-align:right;padding:8px 10px;">—</td>
+            </tr>`;
+    }
+    html += `
+            <tr style="border-top:2px solid var(--border-color);font-weight:800;background:var(--bg-card);">
+                <td style="padding:8px 10px;">TOTAL</td>
+                <td style="text-align:right;padding:8px 10px;color:var(--danger);">${money(agg.totals.spend)}</td>
+                <td style="text-align:right;padding:8px 10px;color:var(--success);">${money(agg.totals.revenue)}</td>
+                <td style="text-align:right;padding:8px 10px;">${agg.totals.adOrders + agg.organic.orders + agg.unattributed.orders}</td>
+                <td style="text-align:right;padding:8px 10px;">${roas(agg.totals.adRevenue, agg.totals.spend)}</td>
+                <td style="text-align:right;padding:8px 10px;">—</td>
+            </tr>
+            </tbody></table></div>`;
+
+    container.innerHTML = html;
+
+    container.querySelectorAll('.region-row').forEach(row => {
+        row.addEventListener('click', () => {
+            const ri = row.dataset.region;
+            const detail = container.querySelector(`.region-detail[data-region="${ri}"]`);
+            const caret = row.querySelector('.region-caret');
+            const open = detail.style.display !== 'none';
+            detail.style.display = open ? 'none' : '';
+            if (caret) caret.style.transform = open ? '' : 'rotate(90deg)';
+        });
+    });
+}
+
+/**
+ * Modal "Regiones": reglas keyword→región (editables) + override manual por
+ * campaña (lista del último reporte) + región default. Persiste en
+ * admin_data/campaign_regions vía services.saveCampaignRegions.
+ *
+ * @param {{ onSaved?:Function }} opts
+ */
+export function openRegionsModal({ onSaved } = {}) {
+    const cfg = getRegionConfig();
+    const working = {
+        rules: cfg.rules.map(r => ({ keyword: r.keyword, region: r.region })),
+        overrides: { ...cfg.overrides },
+        defaultRegion: cfg.defaultRegion || 'Nacional'
+    };
+    const campaigns = _lastCampaignsForRegions.slice().sort((a, b) => String(a.name).localeCompare(String(b.name)));
+
+    const body = `
+        <div style="display:grid;gap:14px;max-width:640px;">
+            <div class="form-group" style="margin:0;">
+                <label style="font-size:12px;color:var(--text-secondary);">Región por defecto (campañas que no matchean ninguna regla)</label>
+                <input type="text" id="reg-default" class="modal-input" value="${escHtml(working.defaultRegion)}" style="width:200px;">
+            </div>
+
+            <div style="border:1px solid var(--border-color);border-radius:10px;padding:12px;">
+                <div style="font-size:11px;text-transform:uppercase;font-weight:700;color:var(--text-secondary);margin-bottom:8px;">
+                    Reglas — si el nombre de la campaña CONTIENE la palabra → región
+                </div>
+                <div id="reg-rules-wrap"></div>
+                <button type="button" id="reg-add-rule" class="btn btn-outline btn-sm" style="margin-top:8px;"><i class="fas fa-plus"></i> Agregar regla</button>
+            </div>
+
+            <details ${campaigns.length ? '' : 'open'} style="border:1px solid var(--border-color);border-radius:10px;padding:12px;">
+                <summary style="cursor:pointer;font-weight:700;font-size:11px;text-transform:uppercase;color:var(--text-secondary);">
+                    Override por campaña (${campaigns.length})
+                </summary>
+                <div style="font-size:11px;color:var(--text-secondary);margin:8px 0;">
+                    Deja vacío para usar las reglas automáticas. Escribe una región para forzar esa campaña a ese grupo.
+                    ${campaigns.length ? '' : '<br><strong>Calcula el reporte primero</strong> para ver aquí la lista de campañas.'}
+                </div>
+                <div id="reg-overrides-wrap" style="max-height:240px;overflow-y:auto;"></div>
+            </details>
+        </div>`;
+
+    showModal({
+        title: 'Regiones de campañas',
+        body,
+        confirmText: 'Guardar regiones',
+        showCancel: true,
+        onConfirm: async () => {
+            // Reglas válidas
+            const rules = [];
+            const seen = new Set();
+            for (const r of working.rules) {
+                const kw = String(r.keyword || '').toLowerCase().trim();
+                const reg = String(r.region || '').trim();
+                if (!kw || kw.length < 2 || !reg) continue;
+                if (seen.has(kw)) continue;
+                seen.add(kw);
+                rules.push({ keyword: kw, region: reg });
+            }
+            // Overrides desde los inputs por campaña
+            const overrides = {};
+            document.querySelectorAll('.reg-ov-input').forEach(inp => {
+                const v = inp.value.trim();
+                if (v) overrides[inp.dataset.cid] = v;
+            });
+            const defaultRegion = document.getElementById('reg-default').value.trim() || 'Nacional';
+
+            try {
+                await services.saveCampaignRegions({ rules, overrides, defaultRegion });
+                showToast('Regiones guardadas', 'success');
+                showModal({ show: false });
+                if (typeof onSaved === 'function') onSaved();
+            } catch (err) {
+                console.error('Error guardando regiones:', err);
+                showToast('No se pudieron guardar las regiones', 'error');
+            }
+        },
+        onModalOpen: () => {
+            const rulesWrap = document.getElementById('reg-rules-wrap');
+            const renderRules = () => {
+                rulesWrap.innerHTML = working.rules.map((r, i) => `
+                    <div style="display:flex;gap:6px;align-items:center;margin-bottom:6px;">
+                        <input type="text" class="modal-input reg-kw" data-idx="${i}" value="${escHtml(r.keyword)}" placeholder="keyword" style="flex:1;padding:5px 8px;font-size:12px;">
+                        <span style="color:var(--text-secondary);">→</span>
+                        <input type="text" class="modal-input reg-region" data-idx="${i}" value="${escHtml(r.region)}" placeholder="región" style="width:150px;padding:5px 8px;font-size:12px;">
+                        <button type="button" class="btn btn-sm reg-del" data-idx="${i}" style="color:var(--danger);padding:2px 8px;"><i class="fas fa-trash"></i></button>
+                    </div>`).join('');
+            };
+            rulesWrap.addEventListener('input', (e) => {
+                const kw = e.target.closest('.reg-kw');
+                const rg = e.target.closest('.reg-region');
+                if (kw) working.rules[parseInt(kw.dataset.idx)].keyword = kw.value;
+                if (rg) working.rules[parseInt(rg.dataset.idx)].region = rg.value;
+            });
+            rulesWrap.addEventListener('click', (e) => {
+                const del = e.target.closest('.reg-del');
+                if (del) { working.rules.splice(parseInt(del.dataset.idx), 1); renderRules(); }
+            });
+            document.getElementById('reg-add-rule').addEventListener('click', () => {
+                working.rules.push({ keyword: '', region: '' });
+                renderRules();
+            });
+            renderRules();
+
+            // Overrides por campaña
+            const ovWrap = document.getElementById('reg-overrides-wrap');
+            ovWrap.innerHTML = campaigns.map(c => `
+                <div style="display:flex;gap:8px;align-items:center;margin-bottom:5px;">
+                    <span style="flex:1;font-size:12px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${escHtml(c.name)}">${escHtml(c.name)}</span>
+                    <input type="text" class="modal-input reg-ov-input" data-cid="${escHtml(c.campaignId)}" value="${escHtml(working.overrides[c.campaignId] || '')}" placeholder="${escHtml(c.region)}" style="width:150px;padding:4px 8px;font-size:12px;">
+                </div>`).join('');
+        }
+    });
+}
+
 export function openRulesModal() {
     // Copia de trabajo local — sólo se persiste al dar "Guardar reglas".
     const working = getActiveKeywordRules().map(r => ({

--- a/public/admon/js/utils.js
+++ b/public/admon/js/utils.js
@@ -327,6 +327,130 @@ export function categorizeWithTrace(concept) {
     return { category: 'SinCategorizar', mechanism: 'ninguno' };
 }
 
+// ===========================================================================
+//  REGIONES DE CAMPAÑAS (pestaña Campañas)
+// ===========================================================================
+
+/**
+ * Reglas semilla para agrupar campañas en regiones por keyword en el nombre.
+ * Editables desde el modal "Regiones"; viven en admin_data/campaign_regions.
+ * Orden = prioridad (primera que matchea gana).
+ */
+export const DEFAULT_REGION_RULES = [
+    { keyword: 'monterrey', region: 'Monterrey' },
+    { keyword: 'mty', region: 'Monterrey' },
+    { keyword: ' nl', region: 'Monterrey' },
+    { keyword: 'durango', region: 'Durango' },
+    { keyword: 'dgo', region: 'Durango' },
+    { keyword: 'saltillo', region: 'Saltillo' }
+];
+export const DEFAULT_REGION = 'Nacional';
+
+/** Config activa de regiones: Firestore si existe, semilla si no. */
+export function getRegionConfig() {
+    const c = state.campaignRegions;
+    return {
+        rules: (c && Array.isArray(c.rules) && c.rules.length) ? c.rules : DEFAULT_REGION_RULES,
+        overrides: (c && c.overrides && typeof c.overrides === 'object') ? c.overrides : {},
+        defaultRegion: (c && c.defaultRegion) ? c.defaultRegion : DEFAULT_REGION
+    };
+}
+
+/**
+ * Resuelve la región de una campaña: override manual por id gana; si no,
+ * primera regla de keyword que matchea el nombre; si nada, región default.
+ */
+export function resolveCampaignRegion(campaignId, campaignName) {
+    const { rules, overrides, defaultRegion } = getRegionConfig();
+    if (campaignId && overrides[campaignId]) return overrides[campaignId];
+    const name = String(campaignName || '').toLowerCase();
+    for (const r of rules) {
+        if (r && r.keyword && name.includes(String(r.keyword).toLowerCase())) return r.region;
+    }
+    return defaultRegion;
+}
+
+/**
+ * Agrega el reporte por región a partir de:
+ *   - report: respuesta de /api/meta-ads/region-report { campaigns, adToCampaign }
+ *   - paidInRange: pedidos Pagado/Fabricar dentro del rango de fechas
+ *
+ * Función PURA (no toca DOM ni red): cruza gasto-por-campaña (Meta) con
+ * venta-por-campaña (pedidos vía attributedAdId→campaña), agrupa por región
+ * y separa los baldes "Orgánico" (sin anuncio) y "Sin atribuir" (anuncio
+ * borrado que no resolvió a campaña).
+ *
+ * @returns {{ regionList:Array, organic:{revenue,orders}, unattributed:{revenue,orders}, totals:Object }}
+ */
+export function buildRegionReport(report, paidInRange) {
+    const campaigns = (report && report.campaigns) || [];
+    const adToCampaign = (report && report.adToCampaign) || {};
+
+    // Campaña id -> { campaignId, name, spend, accountId }
+    const campById = {};
+    campaigns.forEach(c => {
+        if (!c.campaignId) return;
+        if (!campById[c.campaignId]) {
+            campById[c.campaignId] = { campaignId: c.campaignId, name: c.campaignName || c.campaignId, spend: 0, accountId: c.accountId || '' };
+        }
+        campById[c.campaignId].spend += Number(c.spend) || 0;
+    });
+
+    // Venta y pedidos por campaña + baldes orgánico / sin atribuir
+    const revByCampaign = {}, ordersByCampaign = {};
+    const organic = { revenue: 0, orders: 0 };
+    const unattributed = { revenue: 0, orders: 0 };
+
+    paidInRange.forEach(p => {
+        const price = parseFloat(p.precio) || 0;
+        const adId = p.attributedAdId ? String(p.attributedAdId) : null;
+        if (!adId) { organic.revenue += price; organic.orders++; return; }
+        const camp = adToCampaign[adId];
+        if (!camp || !camp.campaignId) { unattributed.revenue += price; unattributed.orders++; return; }
+        revByCampaign[camp.campaignId] = (revByCampaign[camp.campaignId] || 0) + price;
+        ordersByCampaign[camp.campaignId] = (ordersByCampaign[camp.campaignId] || 0) + 1;
+        // Campaña con venta pero sin gasto en el rango (pausada): la incluimos
+        if (!campById[camp.campaignId]) {
+            campById[camp.campaignId] = { campaignId: camp.campaignId, name: camp.campaignName || camp.campaignId, spend: 0, accountId: '' };
+        }
+    });
+
+    const campaignsFull = Object.values(campById).map(c => ({
+        ...c,
+        revenue: revByCampaign[c.campaignId] || 0,
+        orders: ordersByCampaign[c.campaignId] || 0,
+        region: resolveCampaignRegion(c.campaignId, c.name)
+    }));
+
+    const regions = {};
+    campaignsFull.forEach(c => {
+        if (!regions[c.region]) regions[c.region] = { region: c.region, spend: 0, revenue: 0, orders: 0, campaigns: [] };
+        regions[c.region].spend += c.spend;
+        regions[c.region].revenue += c.revenue;
+        regions[c.region].orders += c.orders;
+        regions[c.region].campaigns.push(c);
+    });
+    Object.values(regions).forEach(r => r.campaigns.sort((a, b) => b.spend - a.spend));
+    const regionList = Object.values(regions).sort((a, b) => b.spend - a.spend);
+
+    const adSpend = campaignsFull.reduce((s, c) => s + c.spend, 0);
+    const adRevenue = campaignsFull.reduce((s, c) => s + c.revenue, 0);
+    const adOrders = campaignsFull.reduce((s, c) => s + c.orders, 0);
+
+    return {
+        regionList,
+        organic,
+        unattributed,
+        campaignsFull,
+        totals: {
+            spend: adSpend,
+            adRevenue,
+            adOrders,
+            revenue: adRevenue + organic.revenue + unattributed.revenue
+        }
+    };
+}
+
 /**
  * Recalcula el pago de un empleado.
  */

--- a/public/admon/sw.js
+++ b/public/admon/sw.js
@@ -4,12 +4,11 @@
 //  - JS/CSS/Img estáticos: cache-first con actualización en background
 //  - API/Firestore/Firebase: passthrough (sin cachear)
 
-// v12 (2026-06-12): Fase B del modal Reglas — seccion "Overrides guardados"
-// (ver/buscar/borrar manualCategories + limpieza de huerfanos con aut:/folio:)
-// y boton "aplicar regla a existentes" (rayo) con preview que protege
-// abonos, splits y movimientos manuales/editados, y ofrece borrar overrides
-// en conflicto con la regla.
-const CACHE_VERSION = 'admon-v12';
+// v13 (2026-06-12): pestana "Campanas" — gasto/venta/ROAS por region.
+// Cruza gasto-por-campana de Meta (endpoint region-report) con venta-por-
+// campana de pedidos (attributedAdId->campana), agrupa por region editable
+// (keyword + override por campana). Baldes Organico y Sin atribuir aparte.
+const CACHE_VERSION = 'admon-v13';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const PAGE_CACHE = `${CACHE_VERSION}-pages`;
 

--- a/server/meta/metaAdsService.js
+++ b/server/meta/metaAdsService.js
@@ -434,25 +434,31 @@ async function getCampaignSpendForAccounts(accountIds, dateFrom, dateTo) {
 async function resolveAdsToCampaigns(adIds) {
     const map = {};
     const unique = [...new Set((adIds || []).filter(Boolean).map(String))];
+    const token = await resolveToken(null);
     const BATCH = 50;
     for (let i = 0; i < unique.length; i += BATCH) {
-        const batch = unique.slice(i, i + BATCH);
+        const slice = unique.slice(i, i + BATCH);
+        // Batch API REAL de Meta: cada sub-request es independiente, asi que un
+        // anuncio borrado NO tumba al resto del lote (a diferencia de /?ids=,
+        // que falla entero y obligaba a reintentar 1x1 -> lentisimo). 50/lote.
+        const batch = slice.map(id => ({ method: 'GET', relative_url: `${id}?fields=campaign{id,name}` }));
         try {
-            // path '' -> https://graph.facebook.com/<ver>/?ids=...  (token global)
-            const resp = await metaGet('', { ids: batch.join(','), fields: 'campaign{id,name}' }, null);
-            for (const adId of Object.keys(resp || {})) {
-                const camp = resp[adId] && resp[adId].campaign;
-                if (camp) map[adId] = { campaignId: camp.id, campaignName: camp.name };
-            }
-        } catch (err) {
-            // Si el batch entero falla (un id invalido tumba la llamada),
-            // reintentamos uno por uno para no perder los demas.
-            for (const adId of batch) {
+            const resp = await axios.post(`${META_API_BASE}/`, {
+                access_token: token,
+                batch: JSON.stringify(batch)
+            });
+            const results = Array.isArray(resp.data) ? resp.data : [];
+            results.forEach((r, idx) => {
+                if (!r || r.code !== 200 || !r.body) return; // anuncio borrado/sin acceso
                 try {
-                    const one = await metaGet(adId, { fields: 'campaign{id,name}' }, null);
-                    if (one && one.campaign) map[adId] = { campaignId: one.campaign.id, campaignName: one.campaign.name };
-                } catch (_) { /* anuncio borrado/sin acceso: se omite */ }
-            }
+                    const obj = JSON.parse(r.body);
+                    if (obj && obj.campaign) {
+                        map[slice[idx]] = { campaignId: obj.campaign.id, campaignName: obj.campaign.name };
+                    }
+                } catch (_) { /* body no parseable */ }
+            });
+        } catch (err) {
+            console.error('[META] batch resolve ads error:', err.response?.data || err.message);
         }
     }
     return map;


### PR DESCRIPTION
Backend:
- resolveAdsToCampaigns ahora usa el batch API real de Meta (sub-requests independientes; un anuncio borrado ya no tumba el lote). De ~48s a ~5s.

Admon (pestana nueva Campanas, sw v13):
- cruza gasto-por-campana (region-report) con venta-por-campana de pedidos (attributedAdId->campana), agrupa por region y muestra Gasto/Venta/ Pedidos/ROAS/CPA por grupo, expandible a campanas
- baldes Organico (venta sin anuncio) y Sin atribuir (anuncio borrado)
- modal Regiones: reglas keyword->region editables + override por campana; config en admin_data/campaign_regions con fallback a semilla
- utils.buildRegionReport (pura) + resolveCampaignRegion
- services: listenForCampaignRegions, saveCampaignRegions, fetchRegionReport